### PR TITLE
Place more requirements on Body, reimagine APIs, refactor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub struct Tube {
 }
 
 impl Tube {
-    pub async fn new_range_response_server_opt(
+    pub async fn new_ranged_status_response_server(
         body: &[u8],
         port: Option<u16>,
         status: Option<StatusCode>,
@@ -100,19 +100,6 @@ impl Tube {
             .with_state((Body::new(body), status, headers));
 
         Self::new(app, port).await
-    }
-
-    pub async fn status_response_server(status: axum::http::StatusCode) -> Result<Self, Error> {
-        let app = crate::axum::Router::new().route(
-            "/",
-            crate::axum::routing::get(Self::serve_ranged_status_response).with_state((
-                Body::new(&[]),
-                Some(status),
-                Some(HeaderMap::new()),
-            )),
-        );
-
-        Self::new(app, None).await
     }
 
     /// The "advanced" endpoint constructor uses an Axum Router for its configuration
@@ -197,16 +184,16 @@ impl Tube {
 #[macro_export]
 macro_rules! tube {
     ($body:expr) => {
-        Tube::new_range_response_server_opt($body, None, None, None)
+        Tube::new_ranged_status_response_server($body, None, None, None)
     };
     ($body:expr, $port:expr) => {
-        Tube::new_range_response_server_opt($body, Some($port), None, None)
+        Tube::new_ranged_status_response_server($body, Some($port), None, None)
     };
     ($body:expr, $port:expr, $status:expr) => {
-        Tube::new_range_response_server_opt($body, Some($port), Some($status), None)
+        Tube::new_ranged_status_response_server($body, Some($port), Some($status), None)
     };
     ($body:expr, $port:expr, $status:expr, $headers:expr) => {
-        Tube::new_range_response_server_opt($body, Some($port), Some($status), Some($headers))
+        Tube::new_ranged_status_response_server($body, Some($port), Some($status), Some($headers))
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ pub struct Tube {
 }
 
 impl Tube {
+    /// The "convenience" endpoint constructor. Provide body and optional port, status, headers
     pub async fn new_ranged_status_response_server(
         body: &[u8],
         port: Option<u16>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,5 +320,8 @@ mod tests {
         let client = Client::new();
         let response = client.get(tb.url()).send().await.unwrap();
         assert_eq!(response.status(), 424);
+        assert_eq!(response.content_length(), Some(0));
+        assert!(response.headers().get("date").is_some());
+        assert_eq!(response.bytes().await.unwrap(), vec![]);
     }
 }


### PR DESCRIPTION
Changes
- A body must always be provided, even if it's an empty slice
- Macro apis require a body. Subsequent args allow more customization: body, port, status code, headers.
- Refactor handler code
- Shutdown is async and awaits a response of health shutdown confirmation