### PR TITLE
feat: artificially slow response times

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ No-fuss, low configuration webservers on demand
 - Axum-based, can optionally be constructed from a [Router](https://docs.rs/axum/latest/axum/struct.Router.html)
 - Supports ranged requests using [axum-range](https://github.com/haileys/axum-range)
 - Supports custom headers using [HeaderMap](https://docs.rs/http/1.2.0/http/header/struct.HeaderMap.html)
+- Supports artifically slow response times with configurable delay
 
 ### Example Usage
 
@@ -54,6 +55,31 @@ No-fuss, low configuration webservers on demand
         assert_eq!(tb.url(), "http://0.0.0.0:6301".to_string());
         let client = Client::new();
         let response = client.get(tb.url()).send().await.unwrap();
+        assert_eq!(response.status(), 502);
+        assert_eq!(response.headers().get("pasta").unwrap(), "yum");
+        assert_eq!(response.bytes().await.unwrap(), "potatoes".as_bytes());
+        tb.shutdown().await.unwrap();
+
+        // with port, status, headers, and delay
+        let mut headers = crate::axum::http::HeaderMap::new();
+        headers.append("pasta", crate::axum::http::HeaderValue::from_static("yum"));
+        let delay = std::time::Duration::from_millis(200);
+        let tb = tube!(
+            "potatoes".as_bytes(),
+            Some(6901),
+            Some(StatusCode::BAD_GATEWAY),
+            Some(headers),
+            Some(delay)
+        )
+        .await
+        .unwrap();
+        assert_eq!(tb.url(), "http://0.0.0.0:6901".to_string());
+        let client = Client::new();
+        let start = Instant::now();
+        let response = client.get(tb.url()).send().await.unwrap();
+        assert!(Instant::now() - start >= delay);
+        assert_eq!(response.headers().get("accept-ranges").unwrap(), "bytes");
+        assert_eq!(response.headers().get("content-length").unwrap(), "8");
         assert_eq!(response.status(), 502);
         assert_eq!(response.headers().get("pasta").unwrap(), "yum");
         assert_eq!(response.bytes().await.unwrap(), "potatoes".as_bytes());

--- a/examples/binary.rs
+++ b/examples/binary.rs
@@ -1,0 +1,37 @@
+use tubetti::Tube;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let now = tokio::time::Instant::now();
+    let server_uptime = std::time::Duration::from_secs(20);
+    let shutdown_at = now + server_uptime;
+
+    let mut headers = tubetti::axum::http::HeaderMap::new();
+
+    headers.append(
+        "Content-Type",
+        tubetti::axum::http::HeaderValue::from_static("binary/octet-stream"),
+    );
+
+    let body = "some-body-content".as_bytes();
+    let port = Some(3000);
+    let status = Some(tubetti::axum::http::StatusCode::OK);
+    let headers = Some(headers);
+
+    let tube = tubetti::tube!(body, port, status, headers).await?;
+    let url = tube.url();
+
+    eprintln!();
+    eprintln!(
+        "Server running at {url} :: Will shutdown in {} seconds. Try `curl -H 'Range: bytes=0-7' {url}`",
+        server_uptime.as_secs(),
+    );
+
+    tokio::time::sleep_until(shutdown_at).await;
+
+    tube.shutdown().await?;
+
+    eprintln!(" -> Server shutdown successfully");
+
+    Ok(())
+}

--- a/examples/html.rs
+++ b/examples/html.rs
@@ -1,0 +1,37 @@
+use tubetti::Tube;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let now = tokio::time::Instant::now();
+    let server_uptime = std::time::Duration::from_secs(20);
+    let shutdown_at = now + server_uptime;
+
+    let mut headers = tubetti::axum::http::HeaderMap::new();
+
+    headers.append(
+        "Content-Type",
+        tubetti::axum::http::HeaderValue::from_static("text/html"),
+    );
+
+    let body = "<html><body><h1>Hello World!</h1></body></html>".as_bytes();
+    let port = Some(3000);
+    let status = Some(tubetti::axum::http::StatusCode::OK);
+    let headers = Some(headers);
+
+    let tube = tubetti::tube!(body, port, status, headers).await?;
+    let url = tube.url();
+
+    eprintln!();
+    eprintln!(
+        "Server running at {url} :: Will shutdown in {} seconds. Try opening server URL in browser.",
+        server_uptime.as_secs()
+    );
+
+    tokio::time::sleep_until(shutdown_at).await;
+
+    tube.shutdown().await?;
+
+    eprintln!(" -> Server shutdown successfully");
+
+    Ok(())
+}


### PR DESCRIPTION
Allow responses to (optionally) be slowed down by a configurable `Duration`, making it easier to simulate a server with real-world latency.

Also added a couple of example binaries to make it easier for newcomers to see how to use the library without having to read tests.

> [!NOTE]
> Adding a 4th parameter to the `axum` extractor caused clippy to complain about type complexity. I did not pull the extractor out into a type alias to pacify clippy here but will if desired (for now I just added an `#[expect(...)]` annotation.)